### PR TITLE
Add credentials support to the offline installer

### DIFF
--- a/Dockerfile_qgc-build-android
+++ b/Dockerfile_qgc-build-android
@@ -83,11 +83,13 @@ RUN curl -Lo /tmp/qt/installer.run "https://download.qt.io/archive/qt/$(echo "${
 
 ARG QT_CI_LOGIN
 ARG QT_CI_PASSWORD
+ONBUILD ARG QT_CI_LOGIN=""
+ONBUILD ARG QT_CI_PASSWORD=""
 
 # Unpack Qt toolchains & clean
 RUN QT_PACKAGE_VER=$(echo "${QT_VERSION}" | tr -d .) QT_CI_PACKAGES=qt,qt.qt5.${QT_PACKAGE_VER},qt.qt5.${QT_PACKAGE_VER}.android_armv7,qt.qt5.${QT_PACKAGE_VER}.qtcharts.android_armv7,qt.qt5.${QT_PACKAGE_VER}.qtnetworkauth.android_armv7 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
     && find "${QT_PATH}" -mindepth 1 -maxdepth 1 ! -name "${QT_VERSION}" -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
-    && rm -rf /tmp/*
+    && rm -rf /tmp/* && rm -f "${HOME}/.local/share/Qt/qtaccount.ini"
 
 RUN curl -Lo /tmp/sdk-tools.zip 'https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip' \
 	&& mkdir -p ${ANDROID_HOME} && unzip -q /tmp/sdk-tools.zip -d ${ANDROID_HOME} && rm -f /tmp/sdk-tools.zip \

--- a/Dockerfile_qgc-build-android
+++ b/Dockerfile_qgc-build-android
@@ -78,14 +78,16 @@ RUN dpkg --add-architecture i386 \
 
 COPY scripts/extract-qt-installer.sh /tmp/qt/
 
-# Download & unpack Qt toolchains & clean
-RUN curl -Lo /tmp/qt/installer.run "https://download.qt.io/archive/qt/$(echo "${QT_VERSION}" | cut -d. -f 1-2)/${QT_VERSION}/qt-opensource-linux-x64-${QT_VERSION}.run" \
-	&& QT_PACKAGE_VER=$(echo "${QT_VERSION}" | tr -d .) QT_CI_PACKAGES=qt,qt.qt5.${QT_PACKAGE_VER},qt.qt5.${QT_PACKAGE_VER}.android_armv7,qt.qt5.${QT_PACKAGE_VER}.qtcharts.android_armv7,qt.qt5.${QT_PACKAGE_VER}.qtnetworkauth.android_armv7 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
-	&& find "${QT_PATH}" -mindepth 1 -maxdepth 1 ! -name "${QT_VERSION}" -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
-	&& rm -rf /tmp/*
+# Download
+RUN curl -Lo /tmp/qt/installer.run "https://download.qt.io/archive/qt/$(echo "${QT_VERSION}" | cut -d. -f 1-2)/${QT_VERSION}/qt-opensource-linux-x64-${QT_VERSION}.run"
 
-# Download & unpack android SDK
-# URLs come from here: https://developer.android.com/studio#downloads
+ARG QT_CI_LOGIN
+ARG QT_CI_PASSWORD
+
+# Unpack Qt toolchains & clean
+RUN QT_PACKAGE_VER=$(echo "${QT_VERSION}" | tr -d .) QT_CI_PACKAGES=qt,qt.qt5.${QT_PACKAGE_VER},qt.qt5.${QT_PACKAGE_VER}.android_armv7,qt.qt5.${QT_PACKAGE_VER}.qtcharts.android_armv7,qt.qt5.${QT_PACKAGE_VER}.qtnetworkauth.android_armv7 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
+    && find "${QT_PATH}" -mindepth 1 -maxdepth 1 ! -name "${QT_VERSION}" -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
+    && rm -rf /tmp/*
 
 RUN curl -Lo /tmp/sdk-tools.zip 'https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip' \
 	&& mkdir -p ${ANDROID_HOME} && unzip -q /tmp/sdk-tools.zip -d ${ANDROID_HOME} && rm -f /tmp/sdk-tools.zip \

--- a/Dockerfile_qgc-build-android_arm64_v8a
+++ b/Dockerfile_qgc-build-android_arm64_v8a
@@ -77,11 +77,18 @@ RUN dpkg --add-architecture i386 \
 
 COPY scripts/extract-qt-installer.sh /tmp/qt/
 
-# Download & unpack Qt toolchains & clean
-RUN curl -Lo /tmp/qt/installer.run "https://download.qt.io/archive/qt/$(echo "${QT_VERSION}" | cut -d. -f 1-2)/${QT_VERSION}/qt-opensource-linux-x64-${QT_VERSION}.run" \
-	&& QT_PACKAGE_VER=$(echo "${QT_VERSION}" | tr -d .) QT_CI_PACKAGES=qt,qt.qt5.${QT_PACKAGE_VER},qt.qt5.${QT_PACKAGE_VER}.android_arm64_v8a,qt.qt5.${QT_PACKAGE_VER}.qtcharts.android_arm64_v8a,qt.qt5.${QT_PACKAGE_VER}.qtnetworkauth.android_arm64_v8a /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
-	&& find "${QT_PATH}" -mindepth 1 -maxdepth 1 ! -name "${QT_VERSION}" -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
-	&& rm -rf /tmp/*
+# Download
+RUN curl -Lo /tmp/qt/installer.run "https://download.qt.io/archive/qt/$(echo "${QT_VERSION}" | cut -d. -f 1-2)/${QT_VERSION}/qt-opensource-linux-x64-${QT_VERSION}.run"
+
+ARG QT_CI_LOGIN
+ARG QT_CI_PASSWORD
+ONBUILD ARG QT_CI_LOGIN=""
+ONBUILD ARG QT_CI_PASSWORD=""
+
+# Unpack Qt toolchains & clean
+RUN QT_PACKAGE_VER=$(echo "${QT_VERSION}" | tr -d .) QT_CI_PACKAGES=qt,qt.qt5.${QT_PACKAGE_VER},qt.qt5.${QT_PACKAGE_VER}.android_arm64_v8a,qt.qt5.${QT_PACKAGE_VER}.qtcharts.android_arm64_v8a,qt.qt5.${QT_PACKAGE_VER}.qtnetworkauth.android_arm64_v8a /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
+    && find "${QT_PATH}" -mindepth 1 -maxdepth 1 ! -name "${QT_VERSION}" -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
+    && rm -rf /tmp/* && rm -f "${HOME}/.local/share/Qt/qtaccount.ini"
 
 # Download & unpack android SDK
 RUN curl -Lo /tmp/sdk-tools.zip 'https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip' \

--- a/Dockerfile_qgc-build-linux
+++ b/Dockerfile_qgc-build-linux
@@ -60,11 +60,18 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 
 COPY scripts/extract-qt-installer.sh /tmp/qt/
 
-# Download & unpack Qt toolchains & clean
-RUN curl -Lo /tmp/qt/installer.run "https://download.qt.io/archive/qt/$(echo "${QT_VERSION}" | cut -d. -f 1-2)/${QT_VERSION}/qt-opensource-linux-x64-${QT_VERSION}.run" \
-	&& QT_PACKAGE_VER=$(echo "${QT_VERSION}" | tr -d .) QT_CI_PACKAGES=qt,qt.qt5.${QT_PACKAGE_VER},qt.qt5.${QT_PACKAGE_VER}.gcc_64,qt.qt5.${QT_PACKAGE_VER}.qtcharts,qt.qt5.${QT_PACKAGE_VER}.qtvirtualkeyboard,qt.qt5.${QT_PACKAGE_VER}.qtnetworkauth /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
-	&& find "${QT_PATH}" -mindepth 1 -maxdepth 1 ! -name "${QT_VERSION}" -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
-	&& rm -rf /tmp/*
+# Download
+RUN curl -Lo /tmp/qt/installer.run "https://download.qt.io/archive/qt/$(echo "${QT_VERSION}" | cut -d. -f 1-2)/${QT_VERSION}/qt-opensource-linux-x64-${QT_VERSION}.run"
+
+ARG QT_CI_LOGIN
+ARG QT_CI_PASSWORD
+ONBUILD ARG QT_CI_LOGIN=""
+ONBUILD ARG QT_CI_PASSWORD=""
+
+# Unpack Qt toolchains & clean
+RUN QT_PACKAGE_VER=$(echo "${QT_VERSION}" | tr -d .) QT_CI_PACKAGES=qt,qt.qt5.${QT_PACKAGE_VER},qt.qt5.${QT_PACKAGE_VER}.gcc_64,qt.qt5.${QT_PACKAGE_VER}.qtcharts,qt.qt5.${QT_PACKAGE_VER}.qtvirtualkeyboard,qt.qt5.${QT_PACKAGE_VER}.qtnetworkauth /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
+    && find "${QT_PATH}" -mindepth 1 -maxdepth 1 ! -name "${QT_VERSION}" -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
+    && rm -rf /tmp/* && rm -f "${HOME}/.local/share/Qt/qtaccount.ini"
 
 # Reconfigure locale
 RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --tag $IMAGE_NAME --file=$DOCKERFILE_PATH --build-arg QT_CI_LOGIN=$QT_CI_LOGIN --build-arg QT_CI_PASSWORD=$QT_CI_PASSWORD .

--- a/scripts/extract-qt-installer.sh
+++ b/scripts/extract-qt-installer.sh
@@ -31,7 +31,11 @@ Controller.prototype.WelcomePageCallback = function() {
 }
 
 Controller.prototype.CredentialsPageCallback = function() {
-    gui.clickButton(buttons.CommitButton);
+    // The new offline installer won't 
+    var page = gui.pageWidgetByObjectName("CredentialsPage");
+    page.loginWidget.EmailLineEdit.setText("$QT_CI_LOGIN");
+    page.loginWidget.PasswordLineEdit.setText("$QT_CI_PASSWORD");
+    gui.clickButton(buttons.NextButton);
 }
 
 Controller.prototype.ComponentSelectionPageCallback = function() {


### PR DESCRIPTION
The latest QT installers can't pass the credentials screen without a valid account.
The following ARGs have to be defined at build: QT_CI_LOGIN, QT_CI_PASSWORD