### PR TITLE
deprecate: now hosting container on qgc repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
+# ⚠️ THIS REPOSITORY IS NOW DEPRECATED
+Please find the new QGC containers on the QGC repository under [deploy/docker](https://github.com/mavlink/qgroundcontrol/tree/master/deploy/docker)
+
 # containers
 Docker image for building QGroundControl


### PR DESCRIPTION
We are moving the docker files to the main QGC repo, and we are using them on GH actions, the plan is to publish images to the GH registry